### PR TITLE
fix: administered fix for HostFunctionParamExtraction

### DIFF
--- a/go-wasm-bridge/utils/memory.go
+++ b/go-wasm-bridge/utils/memory.go
@@ -36,8 +36,8 @@ func HostFunctionParamExtraction(args []wasmtime.Val, areInputArgsPresent bool, 
 			inputArg.DataPtrSize = args[1].I32()
 		}
 		if areOutputArgsPresent {
-			outputArg.DataPtr = args[2].I32()
-			outputArg.DataPtrSize = args[3].I32()
+			outputArg.DataPtr = args[0].I32()
+			outputArg.DataPtrSize = args[1].I32()
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in `HostFunctionParamExtraction` for a scenario where only Output args are passed. The length of `args` will always be 2, but in the correct we are trying to access indices `2` and `3` which are Out of Bounds. In this PR, these indices are fixed back to `0` and `1`.