### PR TITLE
Fix: handle nil export in GetExport to prevent panic & Add method GetSmartContractData

### DIFF
--- a/go-wasm-bridge/wasm.go
+++ b/go-wasm-bridge/wasm.go
@@ -194,9 +194,14 @@ func (w *WasmModule) CallFunction(args string) (string, error) {
 	defer w.deallocate(outputLenPtr, 4)
 
 	// Retrieve the wrapper function
-	function := w.instance.GetExport(w.store, wrapperFuncName).Func()
-	if function == nil {
+	extern := w.instance.GetExport(w.store, wrapperFuncName)
+	if extern == nil {
 		return "", fmt.Errorf("function %s does not exist in the contract", funcName)
+	}
+
+	function := extern.Func()
+	if function == nil {
+		return "", fmt.Errorf("export %s is not a function", funcName)
 	}
 
 	// Call the wrapper function


### PR DESCRIPTION
### 1. New Method for Fetching Tokenchain Data

- **Feature:** Added a method to the `wasm-module` struct to fetch the entire tokenchain data.

### 2. Fix: Handle Nil Export in `GetExport`

- **Bug Fix:** Improved the `GetExport` function by adding proper nil checks.
- **Details:** Previously, the function would panic when calling `Func()` on a nil export. This fix ensures missing or non-function exports are handled gracefully, preventing runtime errors.