### PR TITLE
integrating FT start number index into go-wasm-bridge

### DIFF
--- a/go-wasm-bridge/host/ft/host_do_mint_ft_api_call.go
+++ b/go-wasm-bridge/host/ft/host_do_mint_ft_api_call.go
@@ -23,10 +23,11 @@ type DoMintFTApiCall struct {
 }
 
 type MintFTData struct {
-	Did        string `json:"did"`
-	FtCount    int32  `json:"ft_count"`
-	FtName     string `json:"ft_name"`
-	TokenCount int32  `json:"token_count"`
+	Did             string `json:"did"`
+	FtCount         int32  `json:"ft_count"`
+	FtName          string `json:"ft_name"`
+	FtNumStartIndex int32  `json:"ft_num_start_index"`
+	TokenCount      int32  `json:"token_count"`
 }
 
 func NewDoMintFTApiCall() *DoMintFTApiCall {
@@ -74,7 +75,18 @@ func callCreateFTAPI(nodeAddress string, mintFTdata MintFTData) (string, error) 
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(requestBody))
+	// Add ftNumStartIndex as a query parameter
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		fmt.Println("Error parsing URL:", err)
+		return "", err
+	}
+	query := u.Query()
+	query.Set("ftNumStartIndex", fmt.Sprintf("%d", mintFTdata.FtNumStartIndex))
+	u.RawQuery = query.Encode()
+	finalURL := u.String()
+
+	req, err := http.NewRequest("POST", finalURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		fmt.Println("Error creating HTTP request:", err)
 		return "", err

--- a/go-wasm-bridge/wasm.go
+++ b/go-wasm-bridge/wasm.go
@@ -59,7 +59,7 @@ type WasmModuleOption func(*WasmModule)
 func NewWasmModule(wasmFilePath string, registry *HostFunctionRegistry, wasmModuleOpts ...WasmModuleOption) (*WasmModule, error) {
 	// Define Wasm Module with default params
 	wasmModule := &WasmModule{
-		nodeAddress: "http://localhost:20000",
+		nodeAddress: "http://localhost:20006",
 		quorumType:  2,
 	}
 

--- a/packages/std/src/helpers.rs
+++ b/packages/std/src/helpers.rs
@@ -41,6 +41,7 @@ pub struct MintFt {
     pub did:        String, 
     pub ft_count:    i32,
     pub ft_name:    String,
+    pub ft_num_start_index :i32,
     pub token_count: i32,
 }
 


### PR DESCRIPTION
This PR, adds the required code changes into go-wasm-bridge package to integrate the `-ftNumStartIndex`  flag which is done in PR #334 of rubixgoplatform.