### PR TITLE
 updated ft-contract 

### DIFF
--- a/contracts/ft_contract/ft_dapp/go.mod
+++ b/contracts/ft_contract/ft_dapp/go.mod
@@ -2,6 +2,7 @@ module ft_dapp
 
 go 1.22.4
 
-require github.com/rubixchain/rubix-wasm/go-wasm-bridge v0.1.1
-
-require github.com/bytecodealliance/wasmtime-go v1.0.0 // indirect
+require (
+	github.com/bytecodealliance/wasmtime-go v1.0.0 // indirect
+	github.com/rubixchain/rubix-wasm/go-wasm-bridge v0.1.1
+)

--- a/contracts/ft_contract/ft_dapp/go.sum
+++ b/contracts/ft_contract/ft_dapp/go.sum
@@ -2,6 +2,8 @@ github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGy
 github.com/bytecodealliance/wasmtime-go v1.0.0/go.mod h1:jjlqQbWUfVSbehpErw3UoWFndBXRRMvfikYH6KsCwOg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rubixchain/rubix-wasm/go-wasm-bridge v0.1.1 h1:MA42sGR6Oqnka7Z+TKawqyNXKOnmku/cwpe+HotdtV0=

--- a/contracts/ft_contract/ft_dapp/main.go
+++ b/contracts/ft_contract/ft_dapp/main.go
@@ -19,11 +19,28 @@ func executeAndGetContractResult(wasmModule *wasmbridge.WasmModule, contractInpu
 	return contractResult, nil
 }
 
-func mintFTFunc(wasmModule *wasmbridge.WasmModule) {
+func mintFTFunc1(wasmModule *wasmbridge.WasmModule) {
 	contractInput := `{"mint_sample_ft":{"name": "rubix1", "ft_info": {
-  "did": "bafybmihxaehnreq4ygnq3re3soob5znuj7hxoku6aeitdukif75umdv2nu",
-  "ft_count": 100,
-  "ft_name": "test5",
+  "did": "bafybmihho2yn53uxmso4yl6rv2dik35l4gmalt3gypl4ohpxuw7iy4a3ke",
+  "ft_count": 10,
+  "ft_name": "test17",
+  "ft_num_start_index": 0,
+  "token_count": 1
+}}}`
+
+	result, err := executeAndGetContractResult(wasmModule, contractInput)
+	if err != nil {
+		fmt.Printf("unable to execute `mint_sample_ft` Contract function, error: %v\n", err)
+		return
+	}
+	fmt.Println("mint_sample_ft Result: ", result)
+}
+func mintFTFunc2(wasmModule *wasmbridge.WasmModule) {
+	contractInput := `{"mint_sample_ft":{"name": "rubix1", "ft_info": {
+  "did": "bafybmier5otnwn7m7yodowfvzfbobwha3cagyrjphrtifa45jug3tafzxi",
+  "ft_count": 10,
+  "ft_name": "test17",
+  "ft_num_start_index": 10,
   "token_count": 1
 }}}`
 
@@ -64,6 +81,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to initialize WASM module: %v", err)
 	}
-	mintFTFunc(wasmModule)
+	mintFTFunc1(wasmModule)
+	fmt.Println("***First 100 created, trying to create next 100***")
+	mintFTFunc2(wasmModule)
 	//transferFTFunc(wasmModule)
 }


### PR DESCRIPTION
This PR will enable us to create FTs with starting index number. 
For example, we have two DIDs on the same node. Those two DID's want to create each 10 FTs with the same name, so there is a flag called `-ftNumStartIndex` has been added to the create ft API. The corresponding required changes are done to the go-wasm-bridge package in the PR #17. with this current PR, first DID will create 0-9 FTs and second DID will create 9-19 FTs with the same name.